### PR TITLE
Truck reviews page: Add reviews model and display them

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,4 @@
+class Review < ApplicationRecord
+  belongs_to :truck
+  belongs_to :user
+end

--- a/app/models/truck.rb
+++ b/app/models/truck.rb
@@ -1,2 +1,25 @@
+# frozen_string_literal: true
+
 class Truck < ApplicationRecord
+  has_many :reviews
+
+  def reviews_summary
+    summary = {
+      service_rating: 0.0,
+      value_rating: 0.0,
+      cleanliness_rating: 0.0,
+      food_rating: 0.0,
+      average_rating: 0.0,
+    }
+    reviews_count = self.reviews.count.to_f
+
+    self.reviews.each do |review|
+      summary[:service_rating] += (review.service_rating/reviews_count)
+      summary[:value_rating] += (review.value_rating/reviews_count)
+      summary[:cleanliness_rating] += (review.cleanliness_rating/reviews_count)
+      summary[:food_rating] += (review.food_rating/reviews_count)
+      summary[:average_rating] += (review.average_rating/reviews_count)
+    end
+    return summary
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# Users model
 class User < ApplicationRecord
+
   has_secure_password
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -151,7 +151,10 @@
               </div>
               <span class="like-icon"></span>
             </div>
-            <!-- R: Ratings -->
+            <!--  Ratings -->
+						<div class="star-rating" data-rating="<%= item.reviews_summary[:average_rating].round(1) %>">
+							<div class="rating-counter">(<%= item.reviews.count %> reviews)</div>
+						</div>
           </a>
         </div>
         <!-- Listing Item / End -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -186,19 +186,21 @@
 <div id="backtotop"><a href="#"></a></div>
 
 <!-- Booking Sticky Footer -->
-<div class="booking-sticky-footer">
-	<div class="container">
-		<div class="bsf-left">
-			<h4>Starting from $29</h4>
-			<div class="star-rating" data-rating="5">
-				<div class="rating-counter"></div>
+<% if @truck %>
+	<div class="booking-sticky-footer">
+		<div class="container">
+			<div class="bsf-left">
+				<h4><%= @truck.name %></h4>
+				<div class="star-rating" data-rating="<%= @truck.reviews_summary[:average_rating].round(1) %>">
+					<div class="rating-counter"></div>
+				</div>
+			</div>
+			<div class="bsf-right">
+				<a href="#booking-widget-anchor" class="button">Eat now</a>
 			</div>
 		</div>
-		<div class="bsf-right">
-			<a href="#booking-widget-anchor" class="button">Book Now</a>
-		</div>
 	</div>
-</div>
+<% end %>
 
 </div>
 <!-- Wrapper / End -->

--- a/app/views/trucks/show.html.erb
+++ b/app/views/trucks/show.html.erb
@@ -21,6 +21,9 @@
 						<%= @truck.tagline %>
 					</span>
           <!-- R: star reviews -->
+					<div class="star-rating" data-rating="<%= @truck.reviews_summary[:average_rating].round(1) %>">
+						<div class="rating-counter"><a href="#listing-reviews">(<%= @truck.reviews.count %>)</a></div>
+					</div>
 
 				</div>
 			</div>
@@ -139,10 +142,222 @@
 				</div>
 			</div>
 
-			<!-- R: Reviews -->
+			<!-- Reviews -->
+			<div id="listing-reviews" class="listing-section">
+				<h3 class="listing-desc-headline margin-top-75 margin-bottom-20">Reviews <span>(<%= @truck.reviews.count %>)</span></h3>
+
+				<!-- Rating Overview -->
+				<div class="rating-overview">
+					<div class="rating-overview-box">
+						<span class="rating-overview-box-total"><%= @truck.reviews_summary[:average_rating].round(1) %></span>
+						<span class="rating-overview-box-percent">out of 5.0</span>
+						<div class="star-rating" data-rating="<%= @truck.reviews_summary[:average_rating].round(1) %>"></div>
+					</div>
+
+					<div class="rating-bars">
+							<div class="rating-bars-item">
+								<span class="rating-bars-name">Service <i class="tip" data-tip-content="Quality of customer service and attitude to work with you"></i></span>
+								<span class="rating-bars-inner">
+									<span class="rating-bars-rating" data-rating="<%= @truck.reviews_summary[:service_rating].round(1) %>">
+										<span class="rating-bars-rating-inner"></span>
+									</span>
+									<strong><%= @truck.reviews_summary[:service_rating].round(1) %></strong>
+								</span>
+							</div>
+							<div class="rating-bars-item">
+								<span class="rating-bars-name">Value for Money <i class="tip" data-tip-content="Overall experience received for the amount spent"></i></span>
+								<span class="rating-bars-inner">
+									<span class="rating-bars-rating" data-rating="<%= @truck.reviews_summary[:value_rating].round(1) %>">
+										<span class="rating-bars-rating-inner"></span>
+									</span>
+									<strong><%= @truck.reviews_summary[:value_rating].round(1) %></strong>
+								</span>
+							</div>
+							<div class="rating-bars-item">
+								<span class="rating-bars-name">Food <i class="tip" data-tip-content="Overall taste and presentation of the food"></i></span>
+								<span class="rating-bars-inner">
+									<span class="rating-bars-rating" data-rating="<%= @truck.reviews_summary[:food_rating].round(1) %>">
+										<span class="rating-bars-rating-inner"></span>
+									</span>
+									<strong><%= @truck.reviews_summary[:food_rating].round(1) %></strong>
+								</span>
+							</div>
+							<div class="rating-bars-item">
+								<span class="rating-bars-name">Cleanliness <i class="tip" data-tip-content="The physical condition of the business"></i></span>
+								<span class="rating-bars-inner">
+									<span class="rating-bars-rating" data-rating="<%= @truck.reviews_summary[:cleanliness_rating].round(1) %>">
+										<span class="rating-bars-rating-inner"></span>
+									</span>
+									<strong><%= @truck.reviews_summary[:cleanliness_rating].round(1) %></strong>
+								</span>
+							</div>
+					</div>
+				</div>
+				<!-- Rating Overview / End -->
 
 
-			<!-- R: Add Review Box -->
+				<div class="clearfix"></div>
+
+				<!-- Reviews -->
+				<section class="comments listing-reviews">
+					<ul>
+						<% @truck.reviews.each do |review|%>
+						<li>
+							<div class="avatar"><img src="http://www.gravatar.com/avatar/00000000000000000000000000000000?d=mm&amp;s=70" alt="" /></div>
+							<div class="comment-content"><div class="arrow-comment"></div>
+								<div class="comment-by"><%= review.user.name %> <i class="tip" data-tip-content="Person who left this review actually was a customer"></i> <span class="date"><%= time_ago_in_words(review.created_at) %> ago</span>
+									<div class="star-rating" data-rating="<%= review.average_rating %>"></div>
+								</div>
+								<p><%= review.body %></p>
+							</div>
+						</li>
+						<% end %>
+					</ul>
+				</section>
+
+				<!--R: Pagination -->
+
+			</div>
+
+
+			<!-- Add Review Box -->
+			<div id="add-review" class="add-review-box">
+
+				<!-- Add Review -->
+				<h3 class="listing-desc-headline margin-bottom-10">Add Review</h3>
+				<p class="comment-notes">Your email address will not be published.</p>
+
+				<!-- Subratings Container -->
+				<div class="sub-ratings-container">
+
+					<!-- Subrating #1 -->
+					<div class="add-sub-rating">
+						<div class="sub-rating-title">Service <i class="tip" data-tip-content="Quality of customer service and attitude to work with you"></i></div>
+						<div class="sub-rating-stars">
+							<!-- Leave Rating -->
+							<div class="clearfix"></div>
+							<form class="leave-rating">
+								<input type="radio" name="rating" id="rating-1" value="1"/>
+								<label for="rating-1" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-2" value="2"/>
+								<label for="rating-2" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-3" value="3"/>
+								<label for="rating-3" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-4" value="4"/>
+								<label for="rating-4" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-5" value="5"/>
+								<label for="rating-5" class="fa fa-star"></label>
+							</form>
+						</div>
+					</div>
+
+					<!-- Subrating #2 -->
+					<div class="add-sub-rating">
+						<div class="sub-rating-title">Value for Money <i class="tip" data-tip-content="Overall experience received for the amount spent"></i></div>
+						<div class="sub-rating-stars">
+							<!-- Leave Rating -->
+							<div class="clearfix"></div>
+							<form class="leave-rating">
+								<input type="radio" name="rating" id="rating-11" value="1"/>
+								<label for="rating-11" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-12" value="2"/>
+								<label for="rating-12" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-13" value="3"/>
+								<label for="rating-13" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-14" value="4"/>
+								<label for="rating-14" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-15" value="5"/>
+								<label for="rating-15" class="fa fa-star"></label>
+							</form>
+						</div>
+					</div>
+
+					<!-- Subrating #3 -->
+					<div class="add-sub-rating">
+						<div class="sub-rating-title">Location <i class="tip" data-tip-content="Visibility, commute or nearby parking spots"></i></div>
+						<div class="sub-rating-stars">
+							<!-- Leave Rating -->
+							<div class="clearfix"></div>
+							<form class="leave-rating">
+								<input type="radio" name="rating" id="rating-21" value="1"/>
+								<label for="rating-21" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-22" value="2"/>
+								<label for="rating-22" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-23" value="3"/>
+								<label for="rating-23" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-24" value="4"/>
+								<label for="rating-24" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-25" value="5"/>
+								<label for="rating-25" class="fa fa-star"></label>
+							</form>
+						</div>
+					</div>
+
+					<!-- Subrating #4 -->
+					<div class="add-sub-rating">
+						<div class="sub-rating-title">Cleanliness <i class="tip" data-tip-content="The physical condition of the business"></i></div>
+						<div class="sub-rating-stars">
+							<!-- Leave Rating -->
+							<div class="clearfix"></div>
+							<form class="leave-rating">
+								<input type="radio" name="rating" id="rating-31" value="1"/>
+								<label for="rating-31" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-32" value="2"/>
+								<label for="rating-32" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-33" value="3"/>
+								<label for="rating-33" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-34" value="4"/>
+								<label for="rating-34" class="fa fa-star"></label>
+								<input type="radio" name="rating" id="rating-35" value="5"/>
+								<label for="rating-35" class="fa fa-star"></label>
+							</form>
+						</div>
+					</div>
+
+					<!-- Uplaod Photos -->
+	                <div class="uploadButton margin-top-15">
+	                    <input class="uploadButton-input" type="file"  name="attachments[]" accept="image/*, application/pdf" id="upload" multiple/>
+	                    <label class="uploadButton-button ripple-effect" for="upload">Add Photos</label>
+	                    <span class="uploadButton-file-name"></span>
+	                </div>
+	                <!-- Uplaod Photos / End -->
+
+				</div>
+				<!-- Subratings Container / End -->
+
+				<!-- Review Comment -->
+				<form id="add-comment" class="add-comment">
+					<fieldset>
+
+						<div class="row">
+							<div class="col-md-6">
+								<label>Name:</label>
+								<input type="text" value=""/>
+							</div>
+
+							<div class="col-md-6">
+								<label>Email:</label>
+								<input type="text" value=""/>
+							</div>
+						</div>
+
+						<div>
+							<label>Review:</label>
+							<textarea cols="40" rows="3"></textarea>
+						</div>
+
+					</fieldset>
+
+					<button class="button">Submit Review</button>
+					<div class="clearfix"></div>
+				</form>
+
+			</div>
+			<!-- Add Review Box / End -->
+
+
+		</div>
+
 
 
 		</div>

--- a/db/migrate/20190916074058_create_reviews.rb
+++ b/db/migrate/20190916074058_create_reviews.rb
@@ -1,0 +1,16 @@
+class CreateReviews < ActiveRecord::Migration[5.2]
+  def change
+    create_table :reviews do |t|
+      t.bigint :truck_id
+      t.text :body
+      t.integer :service_rating
+      t.integer :value_rating
+      t.integer :cleanliness_rating
+      t.integer :food_rating
+      t.float :average_rating
+      t.bigint :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_12_135515) do
+ActiveRecord::Schema.define(version: 2019_09_16_074058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "reviews", force: :cascade do |t|
+    t.bigint "truck_id"
+    t.text "body"
+    t.integer "service_rating"
+    t.integer "value_rating"
+    t.integer "cleanliness_rating"
+    t.integer "food_rating"
+    t.float "average_rating"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "trucks", force: :cascade do |t|
     t.text "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,3 +50,56 @@ trucks = [
 trucks.each do |t|
   Truck.create(t)
 end
+
+users = [
+  { name: 'Pammy',
+    email: 'pammy@example.com',
+    password: 'abcd'
+  },
+  { name: 'Miguel',
+    email: 'miguel@example.com',
+    password: 'abcd'
+  },
+  { name: 'Frankie',
+    email: 'frankie@example.com',
+    password: 'abcd'
+  },
+]
+
+users.each do |t|
+  User.create(t)
+end
+
+reviews = [
+  { truck_id: 1,
+    body: 'Commodo est luctus eget. Proin in nunc laoreet justo volutpat blandit enim. Sem felis, ullamcorper vel aliquam non, varius eget justo. Duis quis nunc tellus sollicitudin mauris.',
+    service_rating: 3,
+    value_rating: 2,
+    cleanliness_rating: 2,
+    food_rating: 3,
+    average_rating: 2.5,
+    user_id: 1
+  },
+  { truck_id: 1,
+    body: 'Morbi velit eros, sagittis in facilisis non, rhoncus et erat. Nam posuere tristique sem, eu ultricies tortor imperdiet vitae. Curabitur lacinia neque non metus.',
+    service_rating: 4,
+    value_rating: 3,
+    cleanliness_rating: 5,
+    food_rating: 5,
+    average_rating: 4.25,
+    user_id: 2
+  },
+  { truck_id: 1,
+    body: 'Morbi velit eros, sagittis in facilisis non, rhoncus et erat. Nam posuere tristique sem, eu ultricies tortor imperdiet vitae. Curabitur lacinia neque non metus.',
+    service_rating: 1,
+    value_rating: 4,
+    cleanliness_rating: 3,
+    food_rating: 3,
+    average_rating: 2.75,
+    user_id: 3
+  },
+]
+
+reviews.each do |t|
+  Review.create(t)
+end

--- a/public/scripts/custom.js
+++ b/public/scripts/custom.js
@@ -994,7 +994,7 @@ $(document).ready(function(){
 
 					// Refresh sotrable script
 					$(".slots-container").sortable('refresh');
-			} 
+			}
 
 			// Validation Error
 			else {
@@ -1012,14 +1012,14 @@ $(document).ready(function(){
 				daySlots.find(".no-slots")
 						.addClass("no-slots-fadein")
 						.removeClass("no-slots-fadeout");
-			} 
+			}
 		}
 		hideSlotInfo();
 
 
 		// Removing Slot
 	    daySlots.find('.remove-slot').bind('click', function() {
-			$(this).closest('.single-slot').animate({height: 0, opacity: 0}, 'fast', function() { 
+			$(this).closest('.single-slot').animate({height: 0, opacity: 0}, 'fast', function() {
 				$(this).remove();
 			});
 
@@ -1037,7 +1037,7 @@ $(document).ready(function(){
 				daySlots.find(".no-slots")
 						.removeClass("no-slots-fadein")
 						.addClass("no-slots-fadeout");
-			} 
+			}
 		});
 
     });
@@ -1059,7 +1059,7 @@ $(document).ready(function(){
 	      var picker = $(this),
 	          p = picker.find('button:last-child'),
 	          m = picker.find('button:first-child'),
-	          input = picker.find('input'),                 
+	          input = picker.find('input'),
 	          min = parseInt(input.attr('min'), 10),
 	          max = parseInt(input.attr('max'), 10),
 	          inputFunc = function(picker) {
@@ -1070,7 +1070,7 @@ $(document).ready(function(){
 	              m.prop(dis, true);
 	            } else if (i >= max) {
 	              input.val(max);
-	              p.prop(dis, true); 
+	              p.prop(dis, true);
 	              m.prop(dis, false);
 	            } else {
 	              p.prop(dis, false);
@@ -1538,7 +1538,11 @@ function starRating(ratingElem) {
 		var oneHalfStar = starsOutput('star','star half','star empty','star empty','star empty');
 		var oneStar = starsOutput('star','star empty','star empty','star empty','star empty');
 
+		var halfStar = starsOutput('star half','star empty','star empty','star empty','star empty');
+		var zeroStar = starsOutput('star empty','star empty','star empty','star empty','star empty');
+
 		// Rules
+
         if (dataRating >= 4.75) {
             $(this).append(fiveStars);
         } else if (dataRating >= 4.25) {
@@ -1555,10 +1559,14 @@ function starRating(ratingElem) {
             $(this).append(twoStars);
         } else if (dataRating >= 1.25) {
             $(this).append(oneHalfStar);
-        } else if (dataRating < 1.25) {
+        } else if (dataRating >= 0.5) {
             $(this).append(oneStar);
+        } else if (dataRating > 0) {
+            $(this).append(halfStar);
+        } else if (dataRating == 0) {
+            $(this).append(zeroStar);
         }
 
-	});
+  });
 
 } starRating('.star-rating');

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ReviewTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Add model for reviews.
- Add relationships between truck and reviews in models.
- Add a reviews_summary method for averaging all review values.
- Display ratings on each truck on the home page.
- Remove sticky footer from layout page unless its the truck_show page.
- Display ratings and reviews on truck show page. 
- Update javascript for correlating stars to reviews average.
- Update seeds and schema.