### PR TITLE
Truck show page: Embed google map. Clean up map scripts.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -221,11 +221,6 @@
 <script type="text/javascript" src="/scripts/tooltips.min.js"></script>
 <script type="text/javascript" src="/scripts/custom.js"></script>
 
-<!-- Maps -->
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false&amp;language=en"></script>
-<script type="text/javascript" src="/scripts/infobox.min.js"></script>
-<script type="text/javascript" src="/scripts/markerclusterer.js"></script>
-<script type="text/javascript" src="/scripts/maps.js"></script>
 
 <!-- Booking Widget - Quantity Buttons -->
 <script src="/scripts/quantityButtons.js"></script>

--- a/app/views/trucks/show.html.erb
+++ b/app/views/trucks/show.html.erb
@@ -137,8 +137,12 @@
 				<h3 class="listing-desc-headline margin-top-60 margin-bottom-30">Location</h3>
 
 				<div id="singleListingMap-container">
-					<div id="singleListingMap" data-latitude="<%= @truck.latitude %>" data-longitude="<%= @truck.longitude %>" data-map-icon="im im-icon-Hamburger"></div>
-					<a href="#" id="streetView">Street View</a>
+					<iframe
+						width="100%"
+						height="450"
+						frameborder="0" style="border:0"
+						src="https://www.google.com/maps/embed/v1/place?key=AIzaSyBKj5K-zsxRaOHJdjtqvD7KgPBETQGGwxg&q=<%= @truck.latitude %>,<%= @truck.longitude %>&zoom=14" allowfullscreen>
+					</iframe>
 				</div>
 			</div>
 

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -127,6 +127,15 @@ photos = [
     truck_id: 1, path: '/img/trucks/1/4.jpg', is_logo: false, is_menu: false
   },
   {
+    truck_id: 1, path: '/img/trucks/1/5.jpg', is_logo: false, is_menu: false
+  },
+  {
+    truck_id: 1, path: '/img/trucks/1/6.jpg', is_logo: false, is_menu: false
+  },
+  {
+    truck_id: 1, path: '/img/trucks/1/7.jpg', is_logo: false, is_menu: false
+  },
+  {
     truck_id: 2, path: '/img/trucks/2/1.jpg', is_logo: false, is_menu: false
   },
   {


### PR DESCRIPTION
- Add extra photos in development seeds
- Replace Google Maps JS for  Google embed map api
- Remove map scripts on application view