### PR TITLE
Admin authorisation for Admin Dashboard

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -9,7 +9,9 @@ module Admin
     before_action :authenticate_admin
 
     def authenticate_admin
-      # TODO Add authentication logic here.
+      unless defined?(current_user) && current_user.try(:admin?)
+        redirect_to root_path
+      end
     end
 
     # Override this value to specify the number of elements to display at a time

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  root 'home#index'
+
   devise_for :users
 
   namespace :admin do
@@ -28,7 +30,7 @@ Rails.application.routes.draw do
   resources :categories, concerns: :show_paginatable, only: [:show]
 
   resources :photos
-  get '/', to:'home#index'
+
   resources :trucks, concerns: :paginatable, only: [:show, :index]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do

--- a/db/migrate/20190928013414_add_admin_to_users.rb
+++ b/db/migrate/20190928013414_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_27_142823) do
+ActiveRecord::Schema.define(version: 2019_09_28_013414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,7 @@ ActiveRecord::Schema.define(version: 2019_09_27_142823) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "username"
+    t.boolean "admin", default: false
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -66,7 +66,7 @@ end
 
 users = [
   { name: 'Anon',
-    email: 'pammy@example.com',
+    email: 'anon@example.com',
     password: 'abcd'
   },
   { name: 'Pammy',


### PR DESCRIPTION
Only admin users should be able to browse the Admin Dashboard. 
- Added the admin field to the users table
- Added an authorisation check on `Admin::ApplicationController` for the `current_user`
- Fixed a couple of bits (root route and email of anon user in the development seeds)